### PR TITLE
Get tests passing and remove `wait_with_token`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,39 +39,32 @@ jobs:
   doctest:
     <<: *common
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
         environment:
           TOXENV: doctest
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
-  py36-core:
+  py36:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-core
-  pypy3-core:
+          TOXENV: py36
+  py37:
     <<: *common
     docker:
-      - image: pypy
+      - image: circleci/python:3.7
         environment:
-          TOXENV: pypy3-core
+          TOXENV: py37
 workflows:
   version: 2
   test:
     jobs:
       - doctest
       - lint
-      - py35-core
-      - py36-core
-      - pypy3-core
+      - py36
+      - py37

--- a/cancel_token/__init__.py
+++ b/cancel_token/__init__.py
@@ -1,8 +1,7 @@
-from .exceptions import (
+from .exceptions import (  # noqa: F401
     OperationCancelled,
     EventLoopMismatch,
 )
-from .token import (
+from .token import (  # noqa: F401
     CancelToken,
-    wait_with_token,
 )

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,9 +7,6 @@ Cancel Token
 .. autoclass:: cancel_token.CancelToken
   :members:
 
-.. autofuncion:: cancel_token.wait_with_token
-  :members:
-
 Exceptions
 ----------
 

--- a/docs/cancel_token.rst
+++ b/docs/cancel_token.rst
@@ -2,13 +2,148 @@ Cancel Token
 ============
 
 
+Introduction
+------------
+
+A `~cancel_token.CancelToken` is used to trigger cancellation of async
+operations.  This is useful for ``asyncio`` based python applications which
+need a sane pattern for cancelling or timing out.
+
+
 Quick Start
 -----------
 
-TODO
+.. doctest:: python
+
+   >>> import asyncio
+   >>> from cancel_token import CancelToken, OperationCancelled
+   >>> async def run_and_cancel_task():
+   ...     async def some_task(token):
+   ...         print("started task")
+   ...         await token.wait()
+   ...         print('task cancelled')
+   ...     token = CancelToken('demo')
+   ...     asyncio.ensure_future(some_task(token))
+   ...     # give the task a moment to start
+   ...     await asyncio.sleep(0.01)
+   ...     # trigger the cancel token
+   ...     token.trigger()
+   ...     # give the task a moment to complete
+   ...     await asyncio.sleep(0.01)
+   ...
+   >>> loop = asyncio.get_event_loop()
+   >>> loop.run_until_complete(run_and_cancel_task())
+   started task
+   task cancelled
 
 
-Usage Instructions
-------------------
+Basic Usage
+-----------
 
-TODO
+Creation of a `~cancel_token.CancelToken` simply requires providing a name.
+
+
+.. doctest:: python
+
+    >>> CancelToken('demo')
+    <CancelToken: demo>
+
+
+Cancel tokens are triggered by calling the
+:meth:`~cancel_token.CancelToken.trigger` method.  Triggering a cancel token
+causes the following behaviors.
+
+- The property :attr:`~cancel_token.CancelToken.triggered` will return ``True``
+- Any calls to the coroutine :meth:`~cancel_token.CancelToken.wait` will return.
+- Any calls to the method :meth:`~cancel_token.CancelToken.raise_if_triggered` will raise an `~cancel_token.OperationCancelled` exception.
+
+From within your application, you might use the cancel token any number of
+ways.
+
+Loop exit condition
+~~~~~~~~~~~~~~~~~~~~
+
+The property :attr:`~cancel_token.CancelToken.triggered` can be useful as the
+conditional for a ``while`` loop.
+
+.. code-block:: python
+
+    async def my_task(token):
+        while not token.triggered:
+            ... # do something
+
+Or you may want to break out of the loop in a less gracefull manner by raising
+the `~cancel_token.OperationCancelled` exception.
+
+.. code-block:: python
+
+    async def my_task(token):
+        while True:
+            token.raise_if_triggered()
+            ... # do something
+
+
+Waiting for an external signal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    async def main():
+        token = CancelToken('worker')
+
+        asyncio.ensure_future(do_work(token))
+        # wait for work to be completed before proceeding
+        await token.wait()
+
+
+Chaining Tokens
+---------------
+
+One of the more useful patterns is token chaining.  Chaining can be used to
+create a single token which will trigger if any of the tokens it is chained to
+are triggered, 
+
+
+.. doctest:: python
+
+    >>> token_a = CancelToken('token-a')
+    >>> token_b = CancelToken('token-b').chain(token_a)
+    >>> token_a.triggered
+    False
+    >>> token_b.triggered
+    False
+    >>> token_a.trigger()
+    >>> token_a.triggered
+    True
+    >>> token_b.triggered
+    True
+
+In this example we create ``token_b`` which has been chained with ``token_a``.
+``token_b`` can be triggered independently, not effecting ``token_a``.
+However, if ``token_a`` is triggered, it also causes ``token_b`` to be
+triggered.
+
+
+Integration with other async APIs
+---------------------------------
+
+Within the boundaries of your own application it is easy to pass cancel tokens
+around as needed.  However, you will often need cancellations to apply to async
+calls to apis which do not support the cancel token API.
+
+The :meth:`cancel_token.CancelToken.wait_for` function can be used to enforce
+cancellations and timeouts on other async APIs.  It expects any number of
+awaitables as positional arguments as well as an optional ``timeout`` as a
+keyword argument.
+
+.. code-block:: python
+
+    >>> import asyncio
+    >>> from cancel_token import CancelToken
+    >>> loop = asyncio.get_event_loop()
+    >>> token = CancelToken('demo')
+    >>> async def some_3rd_party_api():
+    ...     await asyncio.sleep(10)
+    ...
+    >>> loop.run_until_complete(token.wait_for(some_3rd_party_api(), timeout=0.1))
+    TimeoutError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,8 @@ asyncio-cancel-token
 
 Task cancellation pattern for ``asyncio`` applications.
 
+Inspired by https://vorpus.org/blog/timeouts-and-cancellation-for-humans/
+
 Contents
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
     'test': [
         "pytest==3.3.2",
         "pytest-xdist",
+        "pytest-asyncio==0.8.0",
         "tox>=2.9.1,<3",
     ],
     'lint': [
@@ -60,8 +61,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,py3}-core
+    py{36,37,py3}
     lint
     doctest
 
@@ -22,12 +22,12 @@ ignore=
 [testenv]
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
+    py{36,py3}: pytest {posargs:tests}
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python
-    py35: python3.5
     py36: python3.6
+    py37: python3.7
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
## What was wrong?

Cleanup needed after migrating this library to it's own repository.

## How was it fixed?

- small things to get tests running/fixed
- wrote docs
- removed `wait_with_token` in favor of `CancelToken.wait_for`.  See below
- testing for python 3.6 and 3.7

### Dropping `wait_with_token`

I know we've had this discussion in some form before so forgive me for digging it back up again.  Here are my reasons for wanting to do it this way.

- Simpler and more concise API for end user.

```python
from cancel_token import CancelToken, wait_with_token

token = CancelToken('token')
wait_with_token(asyncio.start_server(...), token=token, timeout=5)

# becomes
from cancel_token import CancelToken

token = CancelToken('token')
token.wait_for(asyncio.start_server(...), timeout=5)
```

- Easier to explain

When writing the documentation, I found it awkward when trying to explain how to use `wait_with_token`.  Having it as a core API of the `CancelToken` class seems to make this easier.

Since we **always** have a `CancelToken` anytime `wait_with_token` is used, it strikes me as something that belongs as part of the core `CancelToken` API.

#### Cute Animal Picture

![cold](https://user-images.githubusercontent.com/824194/42715866-0d5ad384-86b6-11e8-905a-9f256ecb7288.jpg)
