### PR TITLE
fix api docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,14 +4,14 @@ API
 Cancel Token
 ------------
 
-.. autoclass:: cancel_token.CancelToken
+.. autoclass:: cancel_token.token.CancelToken
   :members:
 
 Exceptions
 ----------
 
-.. autoclass:: cancel_token.EventLoopMismatch
+.. autoclass:: cancel_token.exceptions.EventLoopMismatch
   :members:
 
-.. autoclass:: cancel_token.OperationCancelled
+.. autoclass:: cancel_token.exceptions.OperationCancelled
   :members:


### PR DESCRIPTION
## What was wrong?

The API section of the docs was not building correctly.

## How was it fixed?

Fixed class paths.

#### Cute Animal Picture

![maxresdefault](https://user-images.githubusercontent.com/824194/42776148-6f78785c-88f3-11e8-8466-f9ff1c0d2367.jpg)
