### PR TITLE
RFC: Only allow tokens to be triggered by their owner methods

### DIFF
--- a/cancel_token/exceptions.py
+++ b/cancel_token/exceptions.py
@@ -17,3 +17,10 @@ class OperationCancelled(BaseCancelTokenException):
     Raised when an operation was cancelled.
     """
     pass
+
+
+class InvalidTokenTriggerer(BaseCancelTokenException):
+    """
+    Raised when a token is triggered by a method not belonging to its owner.
+    """
+    pass

--- a/tests/test_cancel_token.py
+++ b/tests/test_cancel_token.py
@@ -8,14 +8,27 @@ from cancel_token import (
     EventLoopMismatch,
     OperationCancelled,
 )
+from cancel_token.exceptions import InvalidTokenTriggerer
+
+
+class TokenOwner:
+
+    def __init__(self):
+        self.token = CancelToken(self, 'token')
+
+    def trigger_token(self):
+        self.token.trigger()
 
 
 def test_token_single():
-    token = CancelToken('token')
-    assert not token.triggered
-    token.trigger()
-    assert token.triggered
-    assert token.triggered_token == token
+    owner = TokenOwner()
+    assert not owner.token.triggered
+    owner.trigger_token()
+    assert owner.token.triggered
+    assert owner.token.triggered_token == owner.token
+
+    with pytest.raises(InvalidTokenTriggerer):
+        owner.token.trigger()
 
 
 def test_token_chain_event_loop_mismatch():


### PR DESCRIPTION
@pipermerriam , @carver how do you guys feel about this, as an extra safety net to prevent multiple objects from keeping references to the same token. It'd be accompanied by docs to describe that only methods on the obj passed as the token's owner can trigger it, and any other objects must chain.