### PR TITLE
Proper cancellation of tasks

### DIFF
--- a/cancel_token/__init__.py
+++ b/cancel_token/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import (  # noqa: F401
-    OperationCancelled,
     EventLoopMismatch,
+    OperationCancelled,
 )
 from .token import (  # noqa: F401
     CancelToken,

--- a/cancel_token/token.py
+++ b/cancel_token/token.py
@@ -102,6 +102,9 @@ class CancelToken:
                 loop=self.loop,
             )
         except asyncio.CancelledError as err:
+            # Since we use return_when=asyncio.FIRST_COMPLETED above, we can
+            # be sure none of our futures will be done here, so we don't need
+            # to check if any is done before cancelling.
             for future in futures:
                 future.cancel()
             for future in futures:
@@ -141,6 +144,9 @@ class CancelToken:
                 loop=self.loop,
             )
         except asyncio.CancelledError as err:
+            # Since we use return_when=asyncio.FIRST_COMPLETED above, we can
+            # be sure none of our futures will be done here, so we don't need
+            # to check if any is done before cancelling.
             for future in futures:
                 future.cancel()
             for future in futures:

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v0.2.0-alpha.1 (unreleased)
+--------------
+
+- Change to raise ``asyncio.TimeoutError`` instead of the ``TimeoutError`` from built-ins
+
 v0.1.0-alpha.1
 --------------
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
-        "mypy==0.620",
+        "mypy==0.720",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",
@@ -56,6 +56,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'cancel_token': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==3.3.2",
-        "pytest-xdist",
-        "pytest-asyncio==0.8.0",
-        "tox>=2.9.1,<3",
+        "pytest>=5.1,<5.2",
+        "pytest-xdist>=1.22,<1.23",
+        "pytest-asyncio==0.10.0",
+        "tox>=3.14,<4",
     ],
     'lint': [
         "flake8==3.4.1",

--- a/tests/test_cancel_token.py
+++ b/tests/test_cancel_token.py
@@ -136,14 +136,15 @@ async def test_cancellable_wait_cancels_subtasks_when_cancelled(event_loop):
         # (https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel), so we need
         # the sleep below before we check that the task is actually cancelled.
         await asyncio.wait_for(future, timeout=0.01)
-    await asyncio.sleep(0)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(future, timeout=0.01)
     assert future.cancelled()
     await assert_only_current_task_not_done()
 
 
 @pytest.mark.asyncio
 async def test_cancellable_wait_timeout():
-    with pytest.raises(TimeoutError):
+    with pytest.raises(asyncio.TimeoutError):
         await CancelToken('token').cancellable_wait(asyncio.sleep(0.02), timeout=0.01)
     await assert_only_current_task_not_done()
 


### PR DESCRIPTION
Builds on https://github.com/ethereum/asyncio-cancel-token/pull/14 and https://github.com/ethereum/asyncio-cancel-token/pull/13

## What was wrong?

The python docs for [`asyncio.Future.cancel()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel) say that not only do you need to call `cancel()` but you also need to then await the future and silence the cancellation exception.  Otherwise the event loop doesn't get an opportunity to inject the  `CancelledError` into the running coroutine.

## How was it fixed?

Adjusted the logic to do proper cancellation of background tasks.  This includes some logic cleanup as well to avoid using the `add_finished_callback` mechanism in favor of `try/finally/else` style handling.

I also took the liberty of raising what I think is the *more correct* exception `asyncio.TimeoutError` which is **not** the same as the built-in `TimeoutError`.

#### Cute Animal Picture

![232359044_L3Jatdqa_c](https://user-images.githubusercontent.com/824194/64450012-64704400-d09e-11e9-88f0-cffd512bad71.jpg)

