### PR TITLE
Update mypy and expose type hints

### DIFF
--- a/cancel_token/__init__.py
+++ b/cancel_token/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import (  # noqa: F401
-    OperationCancelled,
     EventLoopMismatch,
+    OperationCancelled,
 )
 from .token import (  # noqa: F401
     CancelToken,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
-        "mypy==0.620",
+        "mypy==0.720",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",
@@ -56,6 +56,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'cancel_token': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==3.3.2",
-        "pytest-xdist",
-        "pytest-asyncio==0.8.0",
-        "tox>=2.9.1,<3",
+        "pytest>=5.1,<5.2",
+        "pytest-xdist>=1.22,<1.23",
+        "pytest-asyncio==0.10.0",
+        "tox>=3.14,<4",
     ],
     'lint': [
         "flake8==3.4.1",


### PR DESCRIPTION
## What was wrong?

Old `mypy` and not exposing type data to 3rd party libraries.

## How was it fixed?

Updated mypy and added PEP561 `py.typed` thing.

#### Cute Animal Picture

![funny-animals-in-costumes](https://user-images.githubusercontent.com/824194/64450447-6e467700-d09f-11e9-8121-d5764479f9b2.jpg)

